### PR TITLE
Send pose/quaternion from Arucotag library over mavlink

### DIFF
--- a/src/Mavlink/Mavlink.cpp
+++ b/src/Mavlink/Mavlink.cpp
@@ -22,12 +22,21 @@ void Mavlink::handle_message(const mavlink_message_t& message)
 	}
 }
 
-void Mavlink::send_landing_target(float angle_x, float angle_y)
+void Mavlink::send_landing_target(float angle_x, float angle_y, float q_x, float q_y, float q_z, float q_w)
 {
 	mavlink_message_t message;
 	mavlink_landing_target_t landing_target = {};
+
+	// X-axis / Y-axis angular offset of the target from the center of the image
 	landing_target.angle_x = angle_x;
 	landing_target.angle_y = angle_y;
+
+	// Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+	landing_target.q[0] = q_w;
+	landing_target.q[1] = q_x;
+	landing_target.q[2] = q_y;
+	landing_target.q[3] = q_z;
+
 
 	mavlink_msg_landing_target_encode(AUTOPILOT_SYS_ID, LANDO_COMPONENT_ID, &message, &landing_target);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,8 @@ ArucoMarkerProcessor::ArucoMarkerProcessor()
 
 	auto callback = [this](ros2_aruco_interfaces::msg::ArucoMarkers::UniquePtr msg) {
 		_last_update_time = this->get_clock()->now();
-		this->send_landing_target(msg->poses[0].position.x, msg->poses[0].position.y, msg->poses[0].position.z);
+		this->send_landing_target(msg->poses[0].position.x, msg->poses[0].position.y, msg->poses[0].position.z,
+			msg->poses[0].orientation.x, msg->poses[0].orientation.y, msg->poses[0].orientation.z, msg->poses[0].orientation.w);
 	};
 
 	_aruco_sub = this->create_subscription<ros2_aruco_interfaces::msg::ArucoMarkers>("aruco_markers", 10, callback);
@@ -54,7 +55,7 @@ ArucoMarkerProcessor::ArucoMarkerProcessor()
 
 // https://mavlink.io/en/services/landing_target.html#positional
 // https://github.com/PX4/PX4-Autopilot/pull/14959
-void ArucoMarkerProcessor::send_landing_target(float x, float y, float z)
+void ArucoMarkerProcessor::send_landing_target(float x, float y, float z, float q_x, float q_y, float q_z, float q_w)
 {
 	// Convert to unit vector
 	float r = sqrtf(x*x + y*y + z*z);
@@ -65,7 +66,7 @@ void ArucoMarkerProcessor::send_landing_target(float x, float y, float z)
 	float tan_theta_x = x / z;
 	float tan_theta_y = y / z;
 
-	_mavlink->send_landing_target(tan_theta_x, tan_theta_y);
+	_mavlink->send_landing_target(tan_theta_x, tan_theta_y, q_x, q_y, q_z, q_w);
 }
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
100% untested. Don't even know if it compiles :sweat_smile: 

We will have to readdress how we are sending position and orientation from the tag over mavlink. The current "simulator pipeline" with sending position as the angular offset, but then including the orientation is not supported by standard PX4.

For now this will do as a prototype and won't cause any harm. The transformation from camera to body frame, and then to NED frame will be handled on the PX4 side.